### PR TITLE
feat(ci): add scheduled upstream sync and sushi30 rebase workflow

### DIFF
--- a/.github/workflows/sync-rebase.yml
+++ b/.github/workflows/sync-rebase.yml
@@ -1,0 +1,86 @@
+name: Sync & Rebase
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sync-rebase:
+    name: Sync upstream and rebase sushi30
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Add upstream remote
+        run: git remote add upstream https://github.com/sipeed/picoclaw.git
+
+      - name: Fetch upstream and origin
+        run: |
+          git fetch upstream
+          git fetch origin
+
+      - name: Sync main from upstream
+        run: |
+          git checkout main
+          git reset --hard upstream/main
+          git push origin main
+
+      - name: Attempt rebase of sushi30 onto main
+        id: rebase
+        run: |
+          git checkout -b sushi30 origin/sushi30
+          if git rebase origin/main; then
+            echo "status=success" >> "$GITHUB_OUTPUT"
+          else
+            CONFLICTS=$(git diff --name-only --diff-filter=U | tr '\n' ' ')
+            echo "status=conflict" >> "$GITHUB_OUTPUT"
+            echo "conflicts=${CONFLICTS}" >> "$GITHUB_OUTPUT"
+            git rebase --abort
+          fi
+
+      - name: Push rebased sushi30
+        if: steps.rebase.outputs.status == 'success'
+        run: git push origin sushi30 --force-with-lease
+
+      - name: Send conflict notification email
+        if: steps.rebase.outputs.status == 'conflict'
+        uses: dawidd6/action-send-mail@v16
+        with:
+          server_address: ${{ secrets.MAIL_SERVER }}
+          server_port: ${{ secrets.MAIL_PORT }}
+          secure: true
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          subject: "[picoclaw] Rebase conflict on sushi30"
+          from: ${{ secrets.MAIL_FROM }}
+          to: ${{ secrets.MAIL_TO }}
+          body: |
+            The scheduled sync-rebase workflow detected conflicts when rebasing sushi30 onto the updated main.
+
+            Conflicting files: ${{ steps.rebase.outputs.conflicts }}
+
+            Resolve manually:
+              git fetch origin
+              git checkout sushi30
+              git rebase origin/main
+
+            Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Fail on conflict
+        if: steps.rebase.outputs.status == 'conflict'
+        run: exit 1


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/sync-rebase.yml` — a daily scheduled workflow that syncs `main` from `upstream` (sipeed/picoclaw) and rebases the `sushi30` branch on top of it
- Sends an SMTP email notification (via `dawidd6/action-send-mail@v16`) listing conflicting files if the rebase fails; aborts cleanly and exits non-zero
- Supports `workflow_dispatch` for manual triggering

## Required secrets

Add these to the repository settings before the workflow can send email:

| Secret | Example |
|---|---|
| `MAIL_SERVER` | `smtp.gmail.com` |
| `MAIL_PORT` | `465` |
| `MAIL_USERNAME` | `you@gmail.com` |
| `MAIL_PASSWORD` | app password |
| `MAIL_FROM` | sender address |
| `MAIL_TO` | recipient address |

> **Note:** For the scheduled trigger to fire, the fork's default branch must be set to `sushi30` (repo Settings → Branches).

## Test plan

- [ ] Add SMTP secrets to repo settings
- [ ] Trigger manually via `workflow_dispatch` and verify `main` is updated and `sushi30` is force-pushed
- [ ] To test conflict notification: add a conflicting commit to `sushi30`, trigger manually, verify email is received and workflow exits as failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)