### PR TITLE
fix(ci): avoid ambiguous main branch checkout in sync-rebase workflow

### DIFF
--- a/.github/workflows/sync-rebase.yml
+++ b/.github/workflows/sync-rebase.yml
@@ -35,16 +35,13 @@ jobs:
           git fetch origin
 
       - name: Sync main from upstream
-        run: |
-          git checkout main
-          git reset --hard upstream/main
-          git push origin main
+        run: git push origin upstream/main:main
 
       - name: Attempt rebase of sushi30 onto main
         id: rebase
         run: |
           git checkout -b sushi30 origin/sushi30
-          if git rebase origin/main; then
+          if git rebase refs/remotes/origin/main; then
             echo "status=success" >> "$GITHUB_OUTPUT"
           else
             CONFLICTS=$(git diff --name-only --diff-filter=U | tr '\n' ' ')


### PR DESCRIPTION
## Summary

- Fixes the `sync-rebase` workflow failing with `fatal: 'main' matched multiple (2) remote tracking branches`
- Replaces the ambiguous `git checkout main` + reset + push with a direct refspec push: `git push origin upstream/main:main`
- Uses `refs/remotes/origin/main` instead of `origin/main` in the rebase step for the same reason

## Root cause

After fetching both `origin` and `upstream`, git sees two remote tracking branches named `main`. The plain `git checkout main` and `git rebase origin/main` commands become ambiguous and fail.

## Test plan

- [ ] Trigger manually via [Actions → Sync & Rebase](https://github.com/sushi30/picoclaw/actions/workflows/sync-rebase.yml) and verify all steps pass

Fixes failure in: https://github.com/sushi30/picoclaw/actions/runs/23735111400

🤖 Generated with [Claude Code](https://claude.com/claude-code)