### PR TITLE
fix(ci): use -B flag to reset sushi30 branch if it already exists

### DIFF
--- a/.github/workflows/sync-rebase.yml
+++ b/.github/workflows/sync-rebase.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Attempt rebase of sushi30 onto main
         id: rebase
         run: |
-          git checkout -b sushi30 origin/sushi30
+          git checkout -B sushi30 origin/sushi30
           if git rebase refs/remotes/origin/main; then
             echo "status=success" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary

Fixes `fatal: a branch named 'sushi30' already exists` in the sync-rebase workflow.

Since the default branch was changed to `sushi30`, `actions/checkout` now checks it out before our steps run. Using `-b` fails because the branch already exists locally — `-B` creates or resets it.

## Verification

Tested locally with a simulation script — the checkout step succeeds and the rebase runs correctly.

Fixes: https://github.com/sushi30/picoclaw/actions/runs/23735542138

🤖 Generated with [Claude Code](https://claude.com/claude-code)