### PR TITLE
ci: add Docker image build workflow for sushi30 branch

### DIFF
--- a/.github/workflows/sushi30-docker.yml
+++ b/.github/workflows/sushi30-docker.yml
@@ -1,0 +1,49 @@
+name: 🐳 Build & Push Docker Image (sushi30)
+
+on:
+  push:
+    branches: ["sushi30"]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: sushi30/picoclaw
+
+jobs:
+  build:
+    name: 🏗️ Build & Push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v6
+
+      - name: 🔧 Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: 🔑 Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🏷️ Compute short SHA
+        id: sha
+        shell: bash
+        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: 🚀 Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sushi30
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ steps.sha.outputs.short }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/sushi30-docker.yml` that triggers on every push to the `sushi30` branch
- Builds `docker/Dockerfile` and pushes to `ghcr.io/sushi30/picoclaw` with two tags: `:sushi30` (rolling latest) and `:sha-<7-char-sha>` (per-commit traceability)
- Uses Docker Buildx with GHA layer cache; `linux/amd64` only (fast branch CI)
- No Docker Hub secrets required — GHCR only via `GITHUB_TOKEN`

Closes #23

## Test plan
- [ ] Merge this PR into `sushi30` and confirm the Actions workflow runs
- [ ] Verify `ghcr.io/sushi30/picoclaw:sushi30` is updated
- [ ] Verify `ghcr.io/sushi30/picoclaw:sha-<sha>` tag is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)