### PR TITLE
feat: add WhatsApp native interactive widget support for user input

### DIFF
--- a/pkg/channels/interfaces.go
+++ b/pkg/channels/interfaces.go
@@ -68,3 +68,38 @@ type PlaceholderRecorder interface {
 type CommandRegistrarCapable interface {
 	RegisterCommands(ctx context.Context, defs []commands.Definition) error
 }
+
+// InteractiveCapable — channels that can send interactive messages with
+// user-selectable options. Implemented by channels that support native
+// widget types such as button quick-replies and list pickers.
+//
+// When the user selects an option the channel emits a normal InboundMessage
+// whose Content is the selected button/row ID and whose Metadata contains:
+//   - "wa_interactive_type":        "button" | "list"
+//   - "wa_interactive_selected_id": the ID that was tapped
+//   - "wa_interactive_display_text": human-readable label the user tapped
+type InteractiveCapable interface {
+	SendButtons(ctx context.Context, chatID, body string, buttons []InteractiveButton) error
+	SendList(ctx context.Context, chatID, body, buttonLabel string, sections []InteractiveSection) error
+}
+
+// InteractiveButton is a single quick-reply button. ID is echoed back as the
+// inbound Content when the user taps; Title is the label displayed on screen.
+// WhatsApp limits buttons to 3 per message and IDs to ~20 characters.
+type InteractiveButton struct {
+	ID    string
+	Title string
+}
+
+// InteractiveSection groups a set of selectable rows in a list message.
+type InteractiveSection struct {
+	Title string
+	Rows  []InteractiveRow
+}
+
+// InteractiveRow is a single selectable item inside an InteractiveSection.
+type InteractiveRow struct {
+	ID          string
+	Title       string
+	Description string // optional sub-text shown below the title
+}

--- a/pkg/channels/manager.go
+++ b/pkg/channels/manager.go
@@ -691,6 +691,14 @@ func (m *Manager) runWorker(ctx context.Context, name string, w *channelWorker) 
 			if !ok {
 				return
 			}
+			// Interactive messages (e.g. WhatsApp buttons/lists) must be
+			// delivered as a single unit — splitting would corrupt the
+			// payload. Dispatch directly and skip all chunking logic.
+			if msg.Metadata["wa_interactive_type"] != "" {
+				m.sendWithRetry(ctx, name, w, msg)
+				continue
+			}
+
 			maxLen := 0
 			if mlp, ok := w.ch.(MessageLengthProvider); ok {
 				maxLen = mlp.MaxMessageLength()

--- a/pkg/channels/whatsapp_native/approver.go
+++ b/pkg/channels/whatsapp_native/approver.go
@@ -1,0 +1,108 @@
+//go:build whatsapp_native
+
+// PicoClaw - Ultra-lightweight personal AI agent
+// License: MIT
+//
+// Copyright (c) 2026 PicoClaw contributors
+
+package whatsapp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/sipeed/picoclaw/pkg/agent"
+	"github.com/sipeed/picoclaw/pkg/channels"
+)
+
+const approvalButtonPrefix = "wa_approval_"
+
+// WhatsAppApprover implements agent.ToolApprover by sending an interactive
+// button message to the user and blocking until they tap Approve or Deny.
+//
+// To use it:
+//  1. Create one with NewWhatsAppApprover(channel).
+//  2. Mount it on the hook manager: hm.Mount(agent.NamedHook("wa_approver", approver)).
+//  3. Pass it to channel.RegisterApprover(approver) so handleInteractiveResponse
+//     can notify it when a matching button ID arrives.
+type WhatsAppApprover struct {
+	ch      *WhatsAppNativeChannel
+	pending sync.Map // reqID (string) → chan bool
+}
+
+// NewWhatsAppApprover creates a WhatsAppApprover for the given channel.
+func NewWhatsAppApprover(ch *WhatsAppNativeChannel) *WhatsAppApprover {
+	return &WhatsAppApprover{ch: ch}
+}
+
+// ApproveTool implements agent.ToolApprover. For whatsapp_native conversations
+// it sends a two-button message and blocks until the user taps Approve or Deny
+// (or the context times out). For other channels it passes through as approved.
+func (a *WhatsAppApprover) ApproveTool(ctx context.Context, req *agent.ToolApprovalRequest) (agent.ApprovalDecision, error) {
+	if req.Channel != "whatsapp_native" {
+		return agent.ApprovalDecision{Approved: true}, nil
+	}
+
+	// Use TurnID as a correlation key — it is unique per agent turn.
+	reqID := req.Meta.TurnID
+	if reqID == "" {
+		return agent.ApprovalDecision{Approved: false, Reason: "missing turn ID for approval correlation"}, nil
+	}
+
+	body := fmt.Sprintf("Tool approval required\n\nTool: %s", req.Tool)
+	btns := []channels.InteractiveButton{
+		{ID: approvalButtonPrefix + "yes_" + reqID, Title: "Approve"},
+		{ID: approvalButtonPrefix + "no_" + reqID, Title: "Deny"},
+	}
+
+	responseCh := make(chan bool, 1)
+	a.pending.Store(reqID, responseCh)
+	defer a.pending.Delete(reqID)
+
+	if err := a.ch.SendButtons(ctx, req.ChatID, body, btns); err != nil {
+		return agent.ApprovalDecision{}, fmt.Errorf("send approval buttons: %w", err)
+	}
+
+	select {
+	case approved := <-responseCh:
+		reason := ""
+		if !approved {
+			reason = "denied by user via WhatsApp"
+		}
+		return agent.ApprovalDecision{Approved: approved, Reason: reason}, nil
+	case <-ctx.Done():
+		return agent.ApprovalDecision{Approved: false, Reason: "approval timed out"}, nil
+	}
+}
+
+// Notify is called by handleInteractiveResponse when a button tap arrives.
+// If the button ID corresponds to a pending approval request, the waiting
+// ApproveTool call is unblocked. Other button IDs are silently ignored.
+func (a *WhatsAppApprover) Notify(buttonID string) {
+	if !strings.HasPrefix(buttonID, approvalButtonPrefix) {
+		return
+	}
+	rest := strings.TrimPrefix(buttonID, approvalButtonPrefix)
+
+	var approved bool
+	var reqID string
+	switch {
+	case strings.HasPrefix(rest, "yes_"):
+		approved = true
+		reqID = strings.TrimPrefix(rest, "yes_")
+	case strings.HasPrefix(rest, "no_"):
+		reqID = strings.TrimPrefix(rest, "no_")
+	default:
+		return
+	}
+
+	if v, ok := a.pending.Load(reqID); ok {
+		ch := v.(chan bool)
+		select {
+		case ch <- approved:
+		default:
+		}
+	}
+}

--- a/pkg/channels/whatsapp_native/interactive.go
+++ b/pkg/channels/whatsapp_native/interactive.go
@@ -1,0 +1,157 @@
+//go:build whatsapp_native
+
+// PicoClaw - Ultra-lightweight personal AI agent
+// License: MIT
+//
+// Copyright (c) 2026 PicoClaw contributors
+
+package whatsapp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/sipeed/picoclaw/pkg/bus"
+	"github.com/sipeed/picoclaw/pkg/channels"
+)
+
+// Metadata keys written by the agent (outbound) and read by Send().
+// These are internal to the whatsapp_native package.
+const (
+	metaKeyInteractiveType = "wa_interactive_type" // "buttons" | "list"
+	metaKeyButtonsJSON     = "wa_buttons_json"     // JSON-encoded []channels.InteractiveButton
+	metaKeyListJSON        = "wa_list_json"        // JSON-encoded []channels.InteractiveSection
+	metaKeyListButtonLabel = "wa_list_button"      // label for the list-open button
+)
+
+// buildInteractiveMessage inspects msg.Metadata for interactive hints and
+// returns the appropriate waE2E.Message, or (nil, nil) if none are present
+// (triggering the plain-text fallback in Send).
+func buildInteractiveMessage(msg bus.OutboundMessage) (*waE2E.Message, error) {
+	switch msg.Metadata[metaKeyInteractiveType] {
+	case "buttons":
+		var btns []channels.InteractiveButton
+		if err := json.Unmarshal([]byte(msg.Metadata[metaKeyButtonsJSON]), &btns); err != nil {
+			return nil, fmt.Errorf("parse buttons json: %w", err)
+		}
+		return buildButtonsMessage(msg.Content, btns), nil
+	case "list":
+		var sections []channels.InteractiveSection
+		if err := json.Unmarshal([]byte(msg.Metadata[metaKeyListJSON]), &sections); err != nil {
+			return nil, fmt.Errorf("parse list json: %w", err)
+		}
+		label := msg.Metadata[metaKeyListButtonLabel]
+		if label == "" {
+			label = "Choose"
+		}
+		return buildListMessage(msg.Content, label, sections), nil
+	default:
+		return nil, nil
+	}
+}
+
+func buildButtonsMessage(body string, buttons []channels.InteractiveButton) *waE2E.Message {
+	waButtons := make([]*waE2E.Button, len(buttons))
+	for i, b := range buttons {
+		waButtons[i] = &waE2E.Button{
+			ButtonId: proto.String(b.ID),
+			ButtonText: &waE2E.Button_ButtonText{
+				DisplayText: proto.String(b.Title),
+			},
+			Type: waE2E.Button_RESPONSE.Enum(),
+		}
+	}
+	return &waE2E.Message{
+		ButtonsMessage: &waE2E.ButtonsMessage{
+			ContentText: proto.String(body),
+			Buttons:     waButtons,
+			HeaderType:  waE2E.ButtonsMessage_EMPTY.Enum(),
+		},
+	}
+}
+
+func buildListMessage(body, buttonLabel string, sections []channels.InteractiveSection) *waE2E.Message {
+	waSections := make([]*waE2E.ListMessage_Section, len(sections))
+	for i, s := range sections {
+		rows := make([]*waE2E.ListMessage_Row, len(s.Rows))
+		for j, r := range s.Rows {
+			rows[j] = &waE2E.ListMessage_Row{
+				RowId:       proto.String(r.ID),
+				Title:       proto.String(r.Title),
+				Description: proto.String(r.Description),
+			}
+		}
+		waSections[i] = &waE2E.ListMessage_Section{
+			Title: proto.String(s.Title),
+			Rows:  rows,
+		}
+	}
+	return &waE2E.Message{
+		ListMessage: &waE2E.ListMessage{
+			Description: proto.String(body),
+			ButtonText:  proto.String(buttonLabel),
+			ListType:    waE2E.ListMessage_SINGLE_SELECT.Enum(),
+			Sections:    waSections,
+		},
+	}
+}
+
+// SendButtons implements channels.InteractiveCapable.
+// It sends a message with up to 3 quick-reply buttons directly via the
+// WhatsApp client (not through the bus/manager). WhatsApp enforces a hard
+// limit of 3 buttons per message; callers are responsible for truncating.
+func (c *WhatsAppNativeChannel) SendButtons(
+	ctx context.Context,
+	chatID, body string,
+	buttons []channels.InteractiveButton,
+) error {
+	c.mu.Lock()
+	client := c.client
+	c.mu.Unlock()
+
+	if client == nil || !client.IsConnected() {
+		return fmt.Errorf("whatsapp not connected")
+	}
+
+	to, err := parseJID(chatID)
+	if err != nil {
+		return fmt.Errorf("invalid chat id %q: %w", chatID, err)
+	}
+
+	waMsg := buildButtonsMessage(body, buttons)
+	if _, err = client.SendMessage(ctx, to, waMsg); err != nil {
+		return fmt.Errorf("send buttons: %w", err)
+	}
+	return nil
+}
+
+// SendList implements channels.InteractiveCapable.
+// It sends a list-picker message with one or more sections of selectable rows.
+func (c *WhatsAppNativeChannel) SendList(
+	ctx context.Context,
+	chatID, body, buttonLabel string,
+	sections []channels.InteractiveSection,
+) error {
+	c.mu.Lock()
+	client := c.client
+	c.mu.Unlock()
+
+	if client == nil || !client.IsConnected() {
+		return fmt.Errorf("whatsapp not connected")
+	}
+
+	to, err := parseJID(chatID)
+	if err != nil {
+		return fmt.Errorf("invalid chat id %q: %w", chatID, err)
+	}
+
+	waMsg := buildListMessage(body, buttonLabel, sections)
+	if _, err = client.SendMessage(ctx, to, waMsg); err != nil {
+		return fmt.Errorf("send list: %w", err)
+	}
+	return nil
+}

--- a/pkg/channels/whatsapp_native/whatsapp_native.go
+++ b/pkg/channels/whatsapp_native/whatsapp_native.go
@@ -59,6 +59,7 @@ type WhatsAppNativeChannel struct {
 	reconnecting bool
 	stopping     atomic.Bool    // set once Stop begins; prevents new wg.Add calls
 	wg           sync.WaitGroup // tracks background goroutines (QR handler, reconnect)
+	approver     *WhatsAppApprover
 }
 
 // NewWhatsAppNativeChannel creates a WhatsApp channel that uses whatsmeow for connection.
@@ -269,7 +270,21 @@ func (c *WhatsAppNativeChannel) Stop(ctx context.Context) error {
 func (c *WhatsAppNativeChannel) eventHandler(evt any) {
 	switch evt.(type) {
 	case *events.Message:
-		c.handleIncoming(evt.(*events.Message))
+		m := evt.(*events.Message)
+		if m.Message == nil {
+			return
+		}
+		// Interactive responses take priority over plain-text extraction.
+		if br := m.Message.GetButtonsResponseMessage(); br != nil {
+			c.handleInteractiveResponse(m, br.GetSelectedButtonId(), "button", br.GetSelectedDisplayText())
+			return
+		}
+		if lr := m.Message.GetListResponseMessage(); lr != nil {
+			sel := lr.GetSingleSelectReply()
+			c.handleInteractiveResponse(m, sel.GetSelectedRowId(), "list", sel.GetTitle())
+			return
+		}
+		c.handleIncoming(m)
 	case *events.Disconnected:
 		logger.InfoCF("whatsapp", "WhatsApp disconnected, will attempt reconnection", nil)
 		c.reconnectMu.Lock()
@@ -425,14 +440,87 @@ func (c *WhatsAppNativeChannel) Send(ctx context.Context, msg bus.OutboundMessag
 		return nil, fmt.Errorf("invalid chat id %q: %w", msg.ChatID, err)
 	}
 
-	waMsg := &waE2E.Message{
-		Conversation: proto.String(msg.Content),
+	waMsg, err := buildInteractiveMessage(msg)
+	if err != nil {
+		return nil, fmt.Errorf("build interactive message: %w", err)
+	}
+	if waMsg == nil {
+		waMsg = &waE2E.Message{Conversation: proto.String(msg.Content)}
 	}
 
 	if _, err = client.SendMessage(ctx, to, waMsg); err != nil {
 		return nil, fmt.Errorf("whatsapp send: %w", channels.ErrTemporary)
 	}
 	return nil, nil
+}
+
+// handleInteractiveResponse processes a button or list-selection tap from the
+// user. It notifies the approver (if one is registered) and then forwards the
+// selection as a normal inbound message so the agent loop can react to it.
+// Content of the resulting InboundMessage is the selected button/row ID,
+// giving the LLM a clean, code-friendly value to match on.
+func (c *WhatsAppNativeChannel) handleInteractiveResponse(
+	evt *events.Message, selectedID, interactiveType, displayText string,
+) {
+	if selectedID == "" {
+		return
+	}
+	senderID := evt.Info.Sender.String()
+	chatID := evt.Info.Chat.String()
+
+	metadata := make(map[string]string)
+	metadata["message_id"] = evt.Info.ID
+	if evt.Info.PushName != "" {
+		metadata["user_name"] = evt.Info.PushName
+	}
+	peerKind := "direct"
+	if evt.Info.Chat.Server == types.GroupServer {
+		peerKind = "group"
+	}
+	metadata["peer_kind"] = peerKind
+	metadata["peer_id"] = chatID
+	metadata["wa_interactive_type"] = interactiveType
+	metadata["wa_interactive_selected_id"] = selectedID
+	metadata["wa_interactive_display_text"] = displayText
+
+	peer := bus.Peer{Kind: peerKind, ID: chatID}
+	sender := bus.SenderInfo{
+		Platform:    "whatsapp",
+		PlatformID:  senderID,
+		CanonicalID: identity.BuildCanonicalID("whatsapp", senderID),
+		DisplayName: evt.Info.PushName,
+	}
+
+	if !c.IsAllowedSender(sender) {
+		return
+	}
+
+	logger.DebugCF(
+		"whatsapp",
+		"WhatsApp interactive response received",
+		map[string]any{
+			"type":        interactiveType,
+			"selected_id": selectedID,
+			"sender_id":   senderID,
+		},
+	)
+
+	// Let the approver handle this first (no-op if ID doesn't match any
+	// pending approval request).
+	if c.approver != nil {
+		c.approver.Notify(selectedID)
+	}
+
+	// Forward as a normal inbound message so the agent loop sees the response.
+	c.HandleMessage(c.runCtx, peer, evt.Info.ID, senderID, chatID, selectedID, nil, metadata, sender)
+}
+
+// RegisterApprover mounts a WhatsAppApprover that will intercept tool
+// approval requests for whatsapp_native conversations and present the user
+// with Approve/Deny buttons. Call this after Start() and before the agent
+// loop begins processing messages.
+func (c *WhatsAppNativeChannel) RegisterApprover(ap *WhatsAppApprover) {
+	c.approver = ap
 }
 
 // parseJID converts a chat ID (phone number or JID string) to types.JID.

--- a/pkg/tools/whatsapp_interactive.go
+++ b/pkg/tools/whatsapp_interactive.go
@@ -1,0 +1,330 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// SendInteractiveCallback is the function type injected into WhatsApp
+// interactive tools so they can publish outbound messages with widget metadata.
+// The metadata map must contain "wa_interactive_type" and the corresponding
+// payload key ("wa_buttons_json" or "wa_list_json").
+type SendInteractiveCallback func(channel, chatID, content string, metadata map[string]string) error
+
+// SendWhatsAppButtonsTool lets the LLM send a WhatsApp message with up to 3
+// quick-reply buttons. The user's tap is delivered back as a normal inbound
+// message whose Content is the tapped button ID.
+type SendWhatsAppButtonsTool struct {
+	sendCallback SendInteractiveCallback
+}
+
+func NewSendWhatsAppButtonsTool() *SendWhatsAppButtonsTool {
+	return &SendWhatsAppButtonsTool{}
+}
+
+func (t *SendWhatsAppButtonsTool) SetSendCallback(cb SendInteractiveCallback) {
+	t.sendCallback = cb
+}
+
+func (t *SendWhatsAppButtonsTool) Name() string {
+	return "send_whatsapp_buttons"
+}
+
+func (t *SendWhatsAppButtonsTool) Description() string {
+	return "Send a WhatsApp message with up to 3 quick-reply buttons so the user can tap a choice. " +
+		"The user's selection is delivered back as the next inbound message with Content equal to the tapped button id. " +
+		"Use this for yes/no questions, approval requests, or any small fixed-choice preference."
+}
+
+func (t *SendWhatsAppButtonsTool) Parameters() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"body": map[string]any{
+				"type":        "string",
+				"description": "Message text displayed above the buttons.",
+			},
+			"buttons": map[string]any{
+				"type":        "array",
+				"description": "List of buttons to show (max 3). The id is returned when the user taps; keep it short and code-friendly (e.g. \"yes\", \"pdf\").",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"id": map[string]any{
+							"type":        "string",
+							"description": "Unique button identifier echoed back as inbound Content when tapped. Max ~20 characters.",
+						},
+						"title": map[string]any{
+							"type":        "string",
+							"description": "Button label shown to the user.",
+						},
+					},
+					"required": []string{"id", "title"},
+				},
+				"maxItems": 3,
+			},
+			"channel": map[string]any{
+				"type":        "string",
+				"description": "Optional: target channel (defaults to current conversation channel).",
+			},
+			"chat_id": map[string]any{
+				"type":        "string",
+				"description": "Optional: target chat/user ID (defaults to current chat).",
+			},
+		},
+		"required": []string{"body", "buttons"},
+	}
+}
+
+func (t *SendWhatsAppButtonsTool) Execute(ctx context.Context, args map[string]any) *ToolResult {
+	body, ok := args["body"].(string)
+	if !ok || body == "" {
+		return &ToolResult{ForLLM: "body is required", IsError: true}
+	}
+
+	rawButtons, ok := args["buttons"].([]any)
+	if !ok || len(rawButtons) == 0 {
+		return &ToolResult{ForLLM: "buttons must be a non-empty array", IsError: true}
+	}
+	if len(rawButtons) > 3 {
+		return &ToolResult{ForLLM: "WhatsApp supports at most 3 buttons per message", IsError: true}
+	}
+
+	type button struct {
+		ID    string `json:"id"`
+		Title string `json:"title"`
+	}
+	btns := make([]button, 0, len(rawButtons))
+	for _, rb := range rawButtons {
+		m, ok := rb.(map[string]any)
+		if !ok {
+			return &ToolResult{ForLLM: "each button must be an object with id and title", IsError: true}
+		}
+		id, _ := m["id"].(string)
+		title, _ := m["title"].(string)
+		if id == "" || title == "" {
+			return &ToolResult{ForLLM: "each button must have a non-empty id and title", IsError: true}
+		}
+		btns = append(btns, button{ID: id, Title: title})
+	}
+
+	btnsJSON, err := json.Marshal(btns)
+	if err != nil {
+		return &ToolResult{ForLLM: fmt.Sprintf("encode buttons: %v", err), IsError: true}
+	}
+
+	channel, _ := args["channel"].(string)
+	chatID, _ := args["chat_id"].(string)
+	if channel == "" {
+		channel = ToolChannel(ctx)
+	}
+	if chatID == "" {
+		chatID = ToolChatID(ctx)
+	}
+
+	if channel == "" || chatID == "" {
+		return &ToolResult{ForLLM: "no target channel/chat — specify channel and chat_id or use from a conversation context", IsError: true}
+	}
+
+	if t.sendCallback == nil {
+		return &ToolResult{ForLLM: "interactive message sending not configured", IsError: true}
+	}
+
+	metadata := map[string]string{
+		"wa_interactive_type": "buttons",
+		"wa_buttons_json":     string(btnsJSON),
+	}
+	if err := t.sendCallback(channel, chatID, body, metadata); err != nil {
+		return &ToolResult{
+			ForLLM:  fmt.Sprintf("send buttons: %v", err),
+			IsError: true,
+			Err:     err,
+		}
+	}
+
+	return &ToolResult{
+		ForLLM: fmt.Sprintf("Button message sent to %s:%s. Waiting for user to tap a button.", channel, chatID),
+		Silent: true,
+	}
+}
+
+// SendWhatsAppListTool lets the LLM send a WhatsApp list-picker message with
+// one or more sections of selectable rows. The user's selection is delivered
+// back as a normal inbound message whose Content is the tapped row ID.
+type SendWhatsAppListTool struct {
+	sendCallback SendInteractiveCallback
+}
+
+func NewSendWhatsAppListTool() *SendWhatsAppListTool {
+	return &SendWhatsAppListTool{}
+}
+
+func (t *SendWhatsAppListTool) SetSendCallback(cb SendInteractiveCallback) {
+	t.sendCallback = cb
+}
+
+func (t *SendWhatsAppListTool) Name() string {
+	return "send_whatsapp_list"
+}
+
+func (t *SendWhatsAppListTool) Description() string {
+	return "Send a WhatsApp list-picker message with one or more sections of selectable items. " +
+		"The user's selection is delivered back as the next inbound message with Content equal to the tapped row id. " +
+		"Use this when there are more than 3 choices or when items benefit from optional descriptions."
+}
+
+func (t *SendWhatsAppListTool) Parameters() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"body": map[string]any{
+				"type":        "string",
+				"description": "Message text displayed above the list.",
+			},
+			"button_label": map[string]any{
+				"type":        "string",
+				"description": "Label for the button that opens the list (e.g. \"Choose format\").",
+			},
+			"sections": map[string]any{
+				"type":        "array",
+				"description": "One or more sections, each with a title and selectable rows.",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"title": map[string]any{
+							"type":        "string",
+							"description": "Section header.",
+						},
+						"rows": map[string]any{
+							"type":        "array",
+							"description": "Selectable rows in this section.",
+							"items": map[string]any{
+								"type": "object",
+								"properties": map[string]any{
+									"id": map[string]any{
+										"type":        "string",
+										"description": "Unique row identifier echoed back as inbound Content when selected.",
+									},
+									"title": map[string]any{
+										"type":        "string",
+										"description": "Row label shown to the user.",
+									},
+									"description": map[string]any{
+										"type":        "string",
+										"description": "Optional sub-text shown below the title.",
+									},
+								},
+								"required": []string{"id", "title"},
+							},
+						},
+					},
+					"required": []string{"title", "rows"},
+				},
+			},
+			"channel": map[string]any{
+				"type":        "string",
+				"description": "Optional: target channel (defaults to current conversation channel).",
+			},
+			"chat_id": map[string]any{
+				"type":        "string",
+				"description": "Optional: target chat/user ID (defaults to current chat).",
+			},
+		},
+		"required": []string{"body", "button_label", "sections"},
+	}
+}
+
+func (t *SendWhatsAppListTool) Execute(ctx context.Context, args map[string]any) *ToolResult {
+	body, ok := args["body"].(string)
+	if !ok || body == "" {
+		return &ToolResult{ForLLM: "body is required", IsError: true}
+	}
+	buttonLabel, _ := args["button_label"].(string)
+	if buttonLabel == "" {
+		buttonLabel = "Choose"
+	}
+
+	rawSections, ok := args["sections"].([]any)
+	if !ok || len(rawSections) == 0 {
+		return &ToolResult{ForLLM: "sections must be a non-empty array", IsError: true}
+	}
+
+	type row struct {
+		ID          string `json:"id"`
+		Title       string `json:"title"`
+		Description string `json:"description,omitempty"`
+	}
+	type section struct {
+		Title string `json:"title"`
+		Rows  []row  `json:"rows"`
+	}
+
+	sections := make([]section, 0, len(rawSections))
+	for _, rs := range rawSections {
+		sm, ok := rs.(map[string]any)
+		if !ok {
+			return &ToolResult{ForLLM: "each section must be an object with title and rows", IsError: true}
+		}
+		title, _ := sm["title"].(string)
+		rawRows, _ := sm["rows"].([]any)
+		if len(rawRows) == 0 {
+			return &ToolResult{ForLLM: "each section must have at least one row", IsError: true}
+		}
+		rows := make([]row, 0, len(rawRows))
+		for _, rr := range rawRows {
+			rm, ok := rr.(map[string]any)
+			if !ok {
+				return &ToolResult{ForLLM: "each row must be an object with id and title", IsError: true}
+			}
+			id, _ := rm["id"].(string)
+			rtitle, _ := rm["title"].(string)
+			desc, _ := rm["description"].(string)
+			if id == "" || rtitle == "" {
+				return &ToolResult{ForLLM: "each row must have a non-empty id and title", IsError: true}
+			}
+			rows = append(rows, row{ID: id, Title: rtitle, Description: desc})
+		}
+		sections = append(sections, section{Title: title, Rows: rows})
+	}
+
+	sectionsJSON, err := json.Marshal(sections)
+	if err != nil {
+		return &ToolResult{ForLLM: fmt.Sprintf("encode sections: %v", err), IsError: true}
+	}
+
+	channel, _ := args["channel"].(string)
+	chatID, _ := args["chat_id"].(string)
+	if channel == "" {
+		channel = ToolChannel(ctx)
+	}
+	if chatID == "" {
+		chatID = ToolChatID(ctx)
+	}
+
+	if channel == "" || chatID == "" {
+		return &ToolResult{ForLLM: "no target channel/chat — specify channel and chat_id or use from a conversation context", IsError: true}
+	}
+
+	if t.sendCallback == nil {
+		return &ToolResult{ForLLM: "interactive message sending not configured", IsError: true}
+	}
+
+	metadata := map[string]string{
+		"wa_interactive_type": "list",
+		"wa_list_json":        string(sectionsJSON),
+		"wa_list_button":      buttonLabel,
+	}
+	if err := t.sendCallback(channel, chatID, body, metadata); err != nil {
+		return &ToolResult{
+			ForLLM:  fmt.Sprintf("send list: %v", err),
+			IsError: true,
+			Err:     err,
+		}
+	}
+
+	return &ToolResult{
+		ForLLM: fmt.Sprintf("List message sent to %s:%s. Waiting for user to select an item.", channel, chatID),
+		Silent: true,
+	}
+}


### PR DESCRIPTION
Introduces button quick-replies and list-picker messages in the
whatsapp_native channel so the LLM can collect preferences and approvals
from users via native WhatsApp widgets rather than plain text.

Changes:
- pkg/channels/interfaces.go: new InteractiveCapable interface with
  InteractiveButton, InteractiveSection, InteractiveRow types
- pkg/channels/whatsapp_native/interactive.go: protobuf builders for
  ButtonsMessage and ListMessage; SendButtons/SendList methods that
  implement InteractiveCapable directly via the whatsmeow client;
  buildInteractiveMessage() reads OutboundMessage.Metadata to dispatch
  interactive sends from the agent-tool path
- pkg/channels/whatsapp_native/whatsapp_native.go: extend eventHandler
  to detect ButtonsResponseMessage and ListResponseMessage events;
  add handleInteractiveResponse helper that notifies the approver and
  forwards the selection as a normal InboundMessage (Content = button ID);
  extend Send() to call buildInteractiveMessage() with plain-text fallback;
  add approver field and RegisterApprover method
- pkg/channels/whatsapp_native/approver.go: WhatsAppApprover implements
  agent.ToolApprover — sends Approve/Deny button message and blocks until
  user taps or context times out; uses TurnID for correlation
- pkg/channels/manager.go: guard in runWorker to skip message splitting
  for interactive messages (wa_interactive_type metadata key present)
- pkg/tools/whatsapp_interactive.go: SendWhatsAppButtonsTool and
  SendWhatsAppListTool — LLM-callable tools that publish OutboundMessages
  with widget metadata; follow existing MessageTool callback pattern

https://claude.ai/code/session_01BLXM4DX8HnkRZDp214H2Dt