### PR TITLE
fix(whatsapp_native): thread VoiceConfig to fix EchoTranscription compile error

### DIFF
--- a/pkg/channels/whatsapp_native/init.go
+++ b/pkg/channels/whatsapp_native/init.go
@@ -15,6 +15,6 @@ func init() {
 		if storePath == "" {
 			storePath = filepath.Join(cfg.WorkspacePath(), "whatsapp")
 		}
-		return NewWhatsAppNativeChannel(waCfg, b, storePath)
+		return NewWhatsAppNativeChannel(waCfg, cfg.Voice, b, storePath)
 	})
 }

--- a/pkg/channels/whatsapp_native/whatsapp_native.go
+++ b/pkg/channels/whatsapp_native/whatsapp_native.go
@@ -51,6 +51,7 @@ const (
 type WhatsAppNativeChannel struct {
 	*channels.BaseChannel
 	config       config.WhatsAppConfig
+	voiceConfig  config.VoiceConfig
 	storePath    string
 	client       *whatsmeow.Client
 	container    *sqlstore.Container
@@ -67,6 +68,7 @@ type WhatsAppNativeChannel struct {
 // storePath is the directory for the SQLite session store (e.g. workspace/whatsapp).
 func NewWhatsAppNativeChannel(
 	cfg config.WhatsAppConfig,
+	voiceCfg config.VoiceConfig,
 	bus *bus.MessageBus,
 	storePath string,
 ) (channels.Channel, error) {
@@ -80,6 +82,7 @@ func NewWhatsAppNativeChannel(
 	c := &WhatsAppNativeChannel{
 		BaseChannel: base,
 		config:      cfg,
+		voiceConfig: voiceCfg,
 		storePath:   storePath,
 	}
 	return c, nil
@@ -428,7 +431,7 @@ func (c *WhatsAppNativeChannel) handleIncoming(evt *events.Message) {
 		metadata["peer_kind"] = "direct"
 		metadata["peer_id"] = senderID
 	}
-	if len(mediaPaths) > 0 && c.config.EchoTranscription {
+	if len(mediaPaths) > 0 && c.voiceConfig.EchoTranscription {
 		metadata["echo_transcription"] = "true"
 	}
 

--- a/pkg/channels/whatsapp_native/whatsapp_native_stub.go
+++ b/pkg/channels/whatsapp_native/whatsapp_native_stub.go
@@ -14,6 +14,7 @@ import (
 // Build with: go build -tags whatsapp_native ./cmd/...
 func NewWhatsAppNativeChannel(
 	cfg config.WhatsAppConfig,
+	voiceCfg config.VoiceConfig,
 	bus *bus.MessageBus,
 	storePath string,
 ) (channels.Channel, error) {


### PR DESCRIPTION
## Summary

- `WhatsAppNativeChannel` was referencing `c.config.EchoTranscription`, but `EchoTranscription` is a field of `config.VoiceConfig`, not `config.WhatsAppConfig`
- This caused the `picoclaw-whatsapp` Docker image build to fail in CI
- Fix: add a `voiceConfig config.VoiceConfig` field to the struct, thread it through `NewWhatsAppNativeChannel`, and pass `cfg.Voice` at the call site in `init.go`; update the stub to match

## Test plan

- [x] `go build -tags whatsapp_native,goolm,stdjson ./pkg/...` compiles cleanly
- [x] `go build ./pkg/channels/whatsapp_native/...` (stub path, no build tag) compiles cleanly
- [x] All Go tests pass (`make test` — frontend lint skipped, pre-existing `node_modules` missing in worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)