### PR TITLE
fix(commands): return error for unrecognized slash commands instead of LLM passthrough

### DIFF
--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -1513,11 +1513,11 @@ func TestProcessMessage_CommandOutcomes(t *testing.T) {
 		Content:  "/foo",
 		Peer:     baseMsg.Peer,
 	})
-	if fooResp != "LLM reply" {
+	if fooResp != "Unknown command: foo" {
 		t.Fatalf("unexpected /foo reply: %q", fooResp)
 	}
-	if provider.calls != 1 {
-		t.Fatalf("LLM should be called exactly once after /foo passthrough, calls=%d", provider.calls)
+	if provider.calls != 0 {
+		t.Fatalf("LLM should not be called for unknown command /foo, calls=%d", provider.calls)
 	}
 
 	newResp := helper.executeAndGetResponse(t, context.Background(), bus.InboundMessage{
@@ -1527,11 +1527,11 @@ func TestProcessMessage_CommandOutcomes(t *testing.T) {
 		Content:  "/new",
 		Peer:     baseMsg.Peer,
 	})
-	if newResp != "LLM reply" {
+	if newResp != "Unknown command: new" {
 		t.Fatalf("unexpected /new reply: %q", newResp)
 	}
-	if provider.calls != 2 {
-		t.Fatalf("LLM should be called for passthrough /new command, calls=%d", provider.calls)
+	if provider.calls != 0 {
+		t.Fatalf("LLM should not be called for unknown command /new, calls=%d", provider.calls)
 	}
 }
 

--- a/pkg/channels/whatsapp_native/whatsapp_native.go
+++ b/pkg/channels/whatsapp_native/whatsapp_native.go
@@ -451,7 +451,10 @@ func (c *WhatsAppNativeChannel) handleIncoming(evt *events.Message) {
 			"WhatsApp message blocked (not in allow_from)",
 			map[string]any{"sender_id": senderID},
 		)
-		_, _ = c.Send(c.runCtx, bus.OutboundMessage{Channel: "whatsapp", ChatID: chatID, Content: channels.ForbiddenReplyText})
+		_, _ = c.Send(
+			c.runCtx,
+			bus.OutboundMessage{Channel: "whatsapp", ChatID: chatID, Content: channels.ForbiddenReplyText},
+		)
 		return
 	}
 
@@ -523,7 +526,6 @@ func isMentionedInGroup(msg *waE2E.Message, content string, botUsers []string) b
 	}
 	return false
 }
-
 
 // VoiceCapabilities reports that this channel supports ASR (speech-to-text).
 func (c *WhatsAppNativeChannel) VoiceCapabilities() channels.VoiceCapabilities {

--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -45,7 +45,10 @@ func (e *Executor) Execute(ctx context.Context, req Request) ExecuteResult {
 	def, found := e.reg.Lookup(cmdName)
 	if !found {
 		// Return an error for unrecognized commands instead of forwarding to LLM
-		err := req.Reply(fmt.Sprintf("Unknown command: %s", cmdName))
+		var err error
+		if req.Reply != nil {
+			err = req.Reply(fmt.Sprintf("Unknown command: %s", cmdName))
+		}
 		return ExecuteResult{Outcome: OutcomeHandled, Command: cmdName, Err: err}
 	}
 

--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -44,7 +44,9 @@ func (e *Executor) Execute(ctx context.Context, req Request) ExecuteResult {
 
 	def, found := e.reg.Lookup(cmdName)
 	if !found {
-		return ExecuteResult{Outcome: OutcomePassthrough, Command: cmdName}
+		// Return an error for unrecognized commands instead of forwarding to LLM
+		err := req.Reply(fmt.Sprintf("Unknown command: %s", cmdName))
+		return ExecuteResult{Outcome: OutcomeHandled, Command: cmdName, Err: err}
 	}
 
 	return e.executeDefinition(ctx, req, def)

--- a/pkg/commands/executor_test.go
+++ b/pkg/commands/executor_test.go
@@ -22,7 +22,10 @@ func TestExecutor_UnknownSlashCommand_ReturnsError(t *testing.T) {
 	ex := NewExecutor(NewRegistry(defs), nil)
 
 	var reply string
-	res := ex.Execute(context.Background(), Request{Channel: "telegram", Text: "/unknown", Reply: func(text string) error { reply = text; return nil }})
+	res := ex.Execute(
+		context.Background(),
+		Request{Channel: "telegram", Text: "/unknown", Reply: func(text string) error { reply = text; return nil }},
+	)
 	if res.Outcome != OutcomeHandled {
 		t.Fatalf("outcome=%v, want=%v", res.Outcome, OutcomeHandled)
 	}

--- a/pkg/commands/executor_test.go
+++ b/pkg/commands/executor_test.go
@@ -17,13 +17,23 @@ func TestExecutor_RegisteredWithoutHandler_ReturnsPassthrough(t *testing.T) {
 	}
 }
 
-func TestExecutor_UnknownSlashCommand_ReturnsPassthrough(t *testing.T) {
+func TestExecutor_UnknownSlashCommand_ReturnsError(t *testing.T) {
 	defs := []Definition{{Name: "show"}}
 	ex := NewExecutor(NewRegistry(defs), nil)
 
-	res := ex.Execute(context.Background(), Request{Channel: "telegram", Text: "/unknown"})
-	if res.Outcome != OutcomePassthrough {
-		t.Fatalf("outcome=%v, want=%v", res.Outcome, OutcomePassthrough)
+	var reply string
+	res := ex.Execute(context.Background(), Request{Channel: "telegram", Text: "/unknown", Reply: func(text string) error { reply = text; return nil }})
+	if res.Outcome != OutcomeHandled {
+		t.Fatalf("outcome=%v, want=%v", res.Outcome, OutcomeHandled)
+	}
+	if res.Command != "unknown" {
+		t.Fatalf("command=%q, want=%q", res.Command, "unknown")
+	}
+	if res.Err != nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if reply != "Unknown command: unknown" {
+		t.Fatalf("reply=%q, want=%q", reply, "Unknown command: unknown")
 	}
 }
 

--- a/pkg/commands/show_list_handlers_test.go
+++ b/pkg/commands/show_list_handlers_test.go
@@ -44,15 +44,20 @@ func TestShowListHandlers_ChannelPolicy(t *testing.T) {
 		t.Fatalf("whatsapp /show reply=%q, want=%q", whatsappReply, "Current Channel: whatsapp")
 	}
 
-	passthrough := ex.Execute(context.Background(), Request{
+	var fooReply string
+	unknown := ex.Execute(context.Background(), Request{
 		Channel: "whatsapp",
 		Text:    "/foo",
+		Reply:   func(text string) error { fooReply = text; return nil },
 	})
-	if passthrough.Outcome != OutcomePassthrough {
-		t.Fatalf("whatsapp /foo outcome=%v, want=%v", passthrough.Outcome, OutcomePassthrough)
+	if unknown.Outcome != OutcomeHandled {
+		t.Fatalf("whatsapp /foo outcome=%v, want=%v", unknown.Outcome, OutcomeHandled)
 	}
-	if passthrough.Command != "foo" {
-		t.Fatalf("whatsapp /foo command=%q, want=%q", passthrough.Command, "foo")
+	if unknown.Command != "foo" {
+		t.Fatalf("whatsapp /foo command=%q, want=%q", unknown.Command, "foo")
+	}
+	if fooReply != "Unknown command: foo" {
+		t.Fatalf("whatsapp /foo reply=%q, want=%q", fooReply, "Unknown command: foo")
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Fixes #45**: Unrecognized slash commands (e.g. `/foo`, `/unknown`) now return an immediate "Unknown command: X" error message to the user instead of being silently forwarded to the LLM.
- Added a nil guard for `req.Reply` in `Executor.Execute` to avoid panics when callers don't provide a reply function.
- Updated all affected tests to assert the new behavior.

## Test plan

- [x] `make test` — all packages pass
- [x] `make vet` — clean
- [x] `make fmt` — clean
- [x] `TestExecutor_UnknownSlashCommand_ReturnsError` verifies unknown commands return `OutcomeHandled` with "Unknown command: X" reply
- [x] `TestShowListHandlers_ChannelPolicy` updated to expect `OutcomeHandled` for unregistered `/foo`
- [x] `TestProcessMessage_CommandOutcomes` updated to verify no LLM call on unknown commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)