### PR TITLE
fix(config): add groq whisper example for voice transcription

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -85,6 +85,12 @@
       "model": "openai/gpt-5.4",
       "api_key": "sk-key2",
       "api_base": "https://api2.example.com/v1"
+    },
+    {
+      "model_name": "groq-whisper",
+      "model": "openai/whisper-large-v3-turbo",
+      "api_key": "your-groq-api-key",
+      "api_base": "https://api.groq.com/openai/v1"
     }
   ],
   "channels": {
@@ -490,7 +496,7 @@
     "monitor_usb": true
   },
   "voice": {
-    "model_name": "",
+    "model_name": "groq-whisper",
     "echo_transcription": false
   },
   "hooks": {


### PR DESCRIPTION
## Summary
- Adds `groq-whisper` model entry to `config.example.json` showing the correct format for Groq Whisper transcription
- Sets `voice.model_name` to `groq-whisper` in the example
- Key: use `openai/whisper-large-v3-turbo` (slash separator, `openai/` prefix) with `api_base` pointing to Groq — the `groq:` prefix format doesn't split correctly in `ExtractProtocol`

## Test plan
- [x] Verified working on live deployment — voice notes transcribed successfully with this config format

🤖 Generated with [Claude Code](https://claude.com/claude-code)